### PR TITLE
fix: handle if ORGANIZATION not provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,4 @@ lint:
 	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 	flake8 . --count --exit-zero --max-complexity=100 --max-line-length=150 --statistics --exclude=venv,.venv,.git,__pycache__
 	pylint --rcfile=.pylintrc --fail-under=9.0 *.py
+	black .

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -50,10 +50,10 @@ def main():  # pragma: no cover
         if not gh_org:
             raise ValueError(
                 f"""Organization {organization} is not an organization and
-                    REPOSITORY environment variable was not set.
-                    Please set valid ORGANIZATION or set REPOSITORY environment
-                    variable
-                """
+            REPOSITORY environment variable was not set.
+            Please set valid ORGANIZATION or set REPOSITORY environment
+            variable
+            """
             )
 
     # Get the repositories from the organization or list of repositories

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -9,13 +9,11 @@ import github3
 
 def get_org(github_connection, organization):
     """Get the organization object"""
-    if organization:
-        try:
-            return github_connection.organization(organization)
-        except github3.exceptions.NotFoundError:
-            print(f"Organization {organization} not found")
-            return None
-    return None
+    try:
+        return github_connection.organization(organization)
+    except github3.exceptions.NotFoundError:
+        print(f"Organization {organization} not found")
+        return None
 
 
 def main():  # pragma: no cover
@@ -42,10 +40,16 @@ def main():  # pragma: no cover
     codeowners_count = 0
     users_count = 0
 
-    gh_org = get_org(github_connection, organization)
-    if not gh_org:
-        print(f"Organization {organization} not found")
-        return
+    if organization and not repository_list:
+        gh_org = get_org(github_connection, organization)
+        if not gh_org:
+            raise ValueError(
+                f"""Organization {organization} is not an organization and
+                    REPOSITORY environment variable was not set.
+                    Please set valid ORGANIZATION or set REPOSITORY environment
+                    variable
+                """
+            )
 
     # Get the repositories from the organization or list of repositories
     repos = get_repos_iterator(organization, repository_list, github_connection)

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -147,9 +147,7 @@ def get_repos_iterator(organization, repository_list, github_connection):
         for full_repo_path in repository_list:
             org = full_repo_path.split("/")[0]
             repo = full_repo_path.split("/")[1]
-            repos.append(
-                github_connection.repository(org, repo)
-            )
+            repos.append(github_connection.repository(org, repo))
 
     return repos
 

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -6,6 +6,7 @@ import auth
 import env
 import github3
 
+
 def get_org(github_connection, organization):
     """Get the organization object"""
     if organization:
@@ -15,6 +16,7 @@ def get_org(github_connection, organization):
             print(f"Organization {organization} not found")
             return None
     return None
+
 
 def main():  # pragma: no cover
     """Run the main program"""
@@ -116,9 +118,7 @@ def main():  # pragma: no cover
                     file_changed = True
                     bytes_username = f"@{username}".encode("ASCII")
                     codeowners_file_contents_new = (
-                        codeowners_file_contents.decoded.replace(
-                            bytes_username, b""
-                        )
+                        codeowners_file_contents.decoded.replace(bytes_username, b"")
                     )
 
         # Update the CODEOWNERS file if usernames were removed

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -85,10 +85,11 @@ def main():  # pragma: no cover
         usernames = get_usernames_from_codeowners(codeowners_file_contents)
 
         for username in usernames:
+            org = organization if organization else repo.owner.login
             # Check to see if the username is a member of the organization
-            if not github_connection.organization(organization).is_member(username):
+            if not github_connection.organization(org).is_member(username):
                 print(
-                    f"\t{username} is not a member of {organization}. Suggest removing them from {repo.full_name}"
+                    f"\t{username} is not a member of {org}. Suggest removing them from {repo.full_name}"
                 )
                 users_count += 1
                 if not dry_run:
@@ -143,9 +144,11 @@ def get_repos_iterator(organization, repository_list, github_connection):
         repos = github_connection.organization(organization).repositories()
     else:
         # Get the repositories from the repository_list
-        for repo in repository_list:
+        for full_repo_path in repository_list:
+            org = full_repo_path.split("/")[0]
+            repo = full_repo_path.split("/")[1]
             repos.append(
-                github_connection.repository(repo.split("/")[0], repo.split("/")[1])
+                github_connection.repository(org, repo)
             )
 
     return repos

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+black==24.2.0
 flake8==7.0.0
 pylint==3.1.0
 pytest==8.1.1

--- a/test_auth.py
+++ b/test_auth.py
@@ -1,4 +1,5 @@
 """Test cases for the auth module."""
+
 import unittest
 from unittest.mock import patch
 

--- a/test_cleanowners.py
+++ b/test_cleanowners.py
@@ -111,7 +111,7 @@ class TestGetReposIterator(unittest.TestCase):
     def test_get_repos_iterator_with_repository_list(self, mock_github):
         """Test the get_repos_iterator function with a repository list"""
         organization = None
-        repository_list = ["org/repo1", "org/repo2"]
+        repository_list = ["org/repo1", "org2/repo2"]
         github_connection = mock_github.return_value
 
         mock_repository = MagicMock()
@@ -123,7 +123,7 @@ class TestGetReposIterator(unittest.TestCase):
         # Assert that the repository method was called with the correct arguments for each repository in the list
         expected_calls = [
             unittest.mock.call("org", "repo1"),
-            unittest.mock.call("org", "repo2"),
+            unittest.mock.call("org2", "repo2"),
         ]
         github_connection.repository.assert_has_calls(expected_calls)
 

--- a/test_cleanowners.py
+++ b/test_cleanowners.py
@@ -1,10 +1,10 @@
 """Test the functions in the cleanowners module."""
 
-import github3
 import unittest
 import uuid
 from unittest.mock import MagicMock, patch
 
+import github3
 from cleanowners import (
     commit_changes,
     get_org,

--- a/test_cleanowners.py
+++ b/test_cleanowners.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from cleanowners import (
     commit_changes,
+    get_org,
     get_repos_iterator,
     get_usernames_from_codeowners,
 )
@@ -79,6 +80,22 @@ class TestGetUsernamesFromCodeowners(unittest.TestCase):
         result = get_usernames_from_codeowners(codeowners_file_contents)
 
         self.assertEqual(result, expected_usernames)
+
+
+class TestGetOrganization(unittest.TestCase):
+    """Test the get_organization function in evergreen.py"""
+
+    @patch("github3.login")
+    def test_get_organization(self, mock_github):
+        """Test the get_organization function."""
+        organization = "my_organization"
+        github_connection = mock_github.return_value
+
+        result = get_org(github_connection, organization)
+
+        github_connection.organization.assert_called_once_with(organization)
+
+        self.assertEqual(result, github_connection.organization.return_value)
 
 
 class TestGetReposIterator(unittest.TestCase):

--- a/test_cleanowners.py
+++ b/test_cleanowners.py
@@ -1,5 +1,6 @@
 """Test the functions in the cleanowners module."""
 
+import os
 import unittest
 import uuid
 from unittest.mock import MagicMock, patch
@@ -9,6 +10,7 @@ from cleanowners import (
     get_org,
     get_repos_iterator,
     get_usernames_from_codeowners,
+    main,
 )
 
 
@@ -82,11 +84,32 @@ class TestGetUsernamesFromCodeowners(unittest.TestCase):
         self.assertEqual(result, expected_usernames)
 
 
+class TestCleanOwnersWithInvalidOrganizationAndNoRepositoryList(unittest.TestCase):
+    """
+    Test the main function in cleanowners.py with an invalid organization and
+    no repository list.
+    """
+
+    @patch("github3.login", "get_env_vars")
+    def test_get_organization_succeeds(self, mock_github, mock_env_vars):
+        """Test the get_organization function."""
+        organization = "my_organization"
+        github_connection = mock_github.return_value
+        env_vars = mock_env_vars.return_value
+
+        result = get_org(github_connection, organization)
+
+        github_connection.organization.assert_called_once_with(organization)
+        self.assertEqual(result, github_connection.organization.return_value)
+
+        with self.assertRaises(ValueError):
+            main()
+
 class TestGetOrganization(unittest.TestCase):
     """Test the get_organization function in evergreen.py"""
 
     @patch("github3.login")
-    def test_get_organization(self, mock_github):
+    def test_get_organization_succeeds(self, mock_github):
         """Test the get_organization function."""
         organization = "my_organization"
         github_connection = mock_github.return_value
@@ -94,7 +117,6 @@ class TestGetOrganization(unittest.TestCase):
         result = get_org(github_connection, organization)
 
         github_connection.organization.assert_called_once_with(organization)
-
         self.assertEqual(result, github_connection.organization.return_value)
 
 


### PR DESCRIPTION
Fixes #27

# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Use each repo's org from REPOSITORY list if ORGANIZTION not provided

This makes sense because the repositories in REPOSITORY could have different organizations

- [x] utilize repo's owner/org  when ORGANIZTION not provided
- [x] show the prefixed org is set when parsing REPOSITORY env var
- [x] update `make lint` to include black
  - [x] add black to requirements-test.txt

We might want additional testing, up to @zkoppert.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
