### PR TITLE
chore: add pull_request_target for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
       - closed
     branches:
       - main
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

- [x] add pull_request_target to release GitHub Action so we have access to fork PR labels

I am not worried about the security implications with us checking out the forked pull requests code. This action only fires after a merge to main so this means the pull request code has been reviewed by a maintainer. We are post-CI/code run.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
