### PR TITLE
fix: update Dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["python", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates
@@ -19,6 +20,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["github_actions", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates
@@ -31,6 +33,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["docker", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Based on [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels--) we can specify the labels applied. Previously Dependabot was applying `major`, `minor', or `patch` labels based on the version of dependency updates. This was causing conflicts with our auto releasing. If those labels were present they were being applied to our releases. This is not what we want. We are chaning to just note the package type (i.e., go, github_actions, etc) and `dependencies`, in case we ever need to filter in the UI.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `make lint` and fix any issues that you have introduced
- [ ] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
