### PR TITLE
feat: propose CODEOWNERS file when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Cleanowners is a GitHub Action that is designed to help keep `CODEOWNERS` files current by removing users that are no longer a part of the organization. This is helpful for companies that are looking to remove outdated information in the `CODEOWNERS` file. This action can be paired with other `CODEOWNERS` related actions to suggest new owners or lint `CODEOWNERS` files to ensure accuracy.
 
+If a repository is missing a `CODEOWNERS` file (or it is empty), the action will open a pull request that adds a placeholder `CODEOWNERS` file for maintainers to update.
+
 This action was developed by the GitHub OSPO for our own use and developed in a way that we could open source it that it might be useful to you as well! If you want to know more about how we use it, reach out in an issue in this repository.
 
 ## Support

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -16,7 +16,7 @@ def write_to_markdown(
             "## Overall Stats\n"
             f"{users_count} Users to Remove\n"
             f"{pull_count} Pull Requests created\n"
-            f"{no_codeowners_count} Repositories with no CODEOWNERS file\n"
+            f"{no_codeowners_count} Repositories missing or empty CODEOWNERS files\n"
             f"{codeowners_count} Repositories with CODEOWNERS file\n"
         )
         if repo_and_users_to_remove:
@@ -27,7 +27,7 @@ def write_to_markdown(
                     file.write(f"- {user}\n")
                 file.write("\n")
         if repos_missing_codeowners:
-            file.write("## Repositories Missing CODEOWNERS\n")
+            file.write("## Repositories Missing or Empty CODEOWNERS\n")
             for repo in repos_missing_codeowners:
                 file.write(f"- {repo}\n")
             file.write("\n")

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -19,7 +19,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 "## Overall Stats\n"
                 "0 Users to Remove\n"
                 "0 Pull Requests created\n"
-                "2 Repositories with no CODEOWNERS file\n"
+                "2 Repositories missing or empty CODEOWNERS files\n"
                 "3 Repositories with CODEOWNERS file\n"
             )
 
@@ -35,7 +35,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                     "## Overall Stats\n"
                     "1 Users to Remove\n"
                     "2 Pull Requests created\n"
-                    "3 Repositories with no CODEOWNERS file\n"
+                    "3 Repositories missing or empty CODEOWNERS files\n"
                     "4 Repositories with CODEOWNERS file\n"
                 ),
                 call("## Repositories and Users to Remove\n"),
@@ -61,10 +61,10 @@ class TestWriteToMarkdown(unittest.TestCase):
                     "## Overall Stats\n"
                     "0 Users to Remove\n"
                     "0 Pull Requests created\n"
-                    "2 Repositories with no CODEOWNERS file\n"
+                    "2 Repositories missing or empty CODEOWNERS files\n"
                     "0 Repositories with CODEOWNERS file\n"
                 ),
-                call("## Repositories Missing CODEOWNERS\n"),
+                call("## Repositories Missing or Empty CODEOWNERS\n"),
                 call("- repo1\n"),
                 call("- repo2\n"),
                 call("\n"),
@@ -81,7 +81,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 "## Overall Stats\n"
                 "0 Users to Remove\n"
                 "0 Pull Requests created\n"
-                "0 Repositories with no CODEOWNERS file\n"
+                "0 Repositories missing or empty CODEOWNERS files\n"
                 "0 Repositories with CODEOWNERS file\n"
             )
 


### PR DESCRIPTION
Fixes #23 

Add placeholder CODEOWNERS content for repos without one, and open a PR instead of skipping.

Tested this on a test repository

https://github.com/vchrombie/cleanowners-test/actions/runs/21336076769/job/61408165828

https://github.com/vchrombie/cleanowners-test/pull/1

---

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`