### PR TITLE
ci: Update contributors action reference after repo transfer

### DIFF
--- a/.github/workflows/contributors_report.yaml
+++ b/.github/workflows/contributors_report.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "END_DATE=$end_date" >> "$GITHUB_ENV"
 
       - name: Run contributor action
-        uses: github/contributors@0d5adc3833e89ee1f4145744f5d69313cf5ea238
+        uses: github-community-projects/contributors@0d5adc3833e89ee1f4145744f5d69313cf5ea238
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}


### PR DESCRIPTION
## Summary

The `github/contributors` action was transferred to `github-community-projects/contributors`. This PR updates references to the old location.

While GitHub does support redirects for transferred repositories, it's best practice to update to the canonical name.